### PR TITLE
docs(search-plus): add sandbox compatibility docs for meta-search

### DIFF
--- a/plugins/search-plus/README.md
+++ b/plugins/search-plus/README.md
@@ -97,6 +97,8 @@ export SEARCH_PLUS_JINA_API_KEY=your_jina_key_here
 
 See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for complete setup details.
 
+> **Sandbox users**: If Claude Code's sandbox is enabled, add `api.tavily.com`, `r.jina.ai`, and `api.jina.ai` to the `allowedDomains` list in your settings. Without these, the extraction script cannot reach external services. See [skills/meta-search/README.md](skills/meta-search/README.md) for details.
+
 ### Option 3: GitHub CLI Integration (Advanced)
 
 Enable native GitHub repository access for maximum reliability with GitHub URLs:

--- a/plugins/search-plus/skills/meta-search/README.md
+++ b/plugins/search-plus/skills/meta-search/README.md
@@ -1,0 +1,49 @@
+# meta-search
+
+Recovers web content when Claude Code's built-in search fails. Part of the [search-plus](../../README.md) plugin.
+
+## Environment variables
+
+| Variable | Required | Service | Free tier |
+|----------|----------|---------|-----------|
+| `SEARCH_PLUS_TAVILY_API_KEY` | No | Tavily extraction API | 1,000 searches/month |
+| `SEARCH_PLUS_JINA_API_KEY` | No | Jina.ai reader API | 20-500 req/min |
+
+Without API keys, the script falls back to free services (SearXNG, DuckDuckGo, Startpage) which have varying reliability.
+
+## Sandbox configuration
+
+When Claude Code's sandbox is enabled, add the extraction service domains to `allowedDomains`:
+
+```jsonc
+// ~/.claude/settings.json
+{
+  "sandbox": {
+    "network": {
+      "allowedDomains": [
+        "api.tavily.com",
+        "r.jina.ai",
+        "api.jina.ai"
+      ]
+    }
+  }
+}
+```
+
+Free fallback services use dynamic domains that cannot be fully allowlisted. For best results with sandbox enabled, configure API keys for Tavily and/or Jina.ai.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | Skill instructions loaded by Claude Code |
+| `scripts/search.mjs` | Main recovery script |
+| `scripts/content-extractor.mjs` | URL content extraction logic |
+| `scripts/handle-search-error.mjs` | Search error recovery handler |
+| `scripts/handle-web-search.mjs` | Web search orchestration |
+| `scripts/handle-rate-limit.mjs` | Rate limit handling |
+| `scripts/hook-entry.mjs` | PostToolUse hook entry point |
+| `scripts/response-transformer.mjs` | Response format transformation |
+| `scripts/search-response.mjs` | Response formatting |
+| `scripts/security-utils.mjs` | Security utilities |
+| `scripts/github-service.mjs` | GitHub CLI integration |

--- a/plugins/search-plus/skills/meta-search/SKILL.md
+++ b/plugins/search-plus/skills/meta-search/SKILL.md
@@ -60,9 +60,33 @@ Apply the strategy matching the error type:
 - On partial success: return what was found, note what remains inaccessible
 - On failure: report which strategies were tried and why they failed
 
+## Sandbox compatibility
+
+The extraction script makes outbound requests to external services. If Claude Code's sandbox is enabled, these domains must be in the `allowedDomains` list:
+
+```jsonc
+// ~/.claude/settings.json
+{
+  "sandbox": {
+    "network": {
+      "allowedDomains": [
+        "api.tavily.com",
+        "r.jina.ai",
+        "api.jina.ai"
+      ]
+    }
+  }
+}
+```
+
+Without these, all extraction services will fail with `fetch failed` and the script will fall through to Step 2 (manual recovery).
+
+Free fallback services (SearXNG, DuckDuckGo, Startpage) use varying domains that cannot be fully allowlisted. For reliable extraction with sandbox enabled, configure API keys for Tavily and/or Jina.ai and add their domains above.
+
 ## Limitations
 
 - Cannot bypass CAPTCHA or advanced bot protection
 - Some paywalled content remains inaccessible
 - Cache/archive services may have stale content
 - PostToolUse hook does not intercept tool-level exceptions (PostToolUseFailure)
+- Free fallback services may not work with sandbox enabled (dynamic domains)


### PR DESCRIPTION
## Summary
- Add sandbox compatibility section to `skills/meta-search/SKILL.md` with required `allowedDomains`
- Create `skills/meta-search/README.md` with env vars, sandbox config, and file reference
- Add sandbox note to plugin `README.md`

## Context
When Claude Code's sandbox is enabled, the meta-search extraction script fails silently with `fetch failed` for all services (Tavily, Jina, free fallbacks) because `api.tavily.com`, `r.jina.ai`, and `api.jina.ai` are not in the default `allowedDomains`. This docs the fix.

## Test plan
- [ ] Verify sandbox config example is valid JSON
- [ ] Confirm domain list covers all extraction service endpoints

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5 Turbo